### PR TITLE
Params kidney fix

### DIFF
--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_1.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_1.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_2.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_2.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_3.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_3.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_4.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_4.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_5.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_5.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_6.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30ArmsSims/ParamsNormalArm30_6.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_1.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_1.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 1.40
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 6.2
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_2.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_2.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 5.60
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_3.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_3.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 1.30
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 6.20
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_4.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_4.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 1.250
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 6.20
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_5.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_5.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 1.05
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 5.60
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_6.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg30LegsSims/ParamsNormalLeg30_6.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 1.250
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 6.10
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 1.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_1.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_1.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.50
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_10.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_10.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.1
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_11.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_11.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.35
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_12.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_12.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 13.2
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_13.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_13.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.35
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_14.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_14.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.75
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_15.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_15.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.5
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_16.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_16.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.5
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_17.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_17.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.7
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_18.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_18.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.1
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_19.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_19.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.55
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_2.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_2.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.30
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_20.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_20.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 13.5
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_3.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_3.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.25
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_4.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_4.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.10
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_5.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_5.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 13.50
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_6.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_6.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.35
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_7.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_7.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_8.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_8.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 15.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_9.txt
+++ b/conf_files_and_scripts/validation_exercise_event/ahlborg58sims/ParamsNormal58_9.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 14.6
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_meal_event/ParamsDiab.txt
+++ b/conf_files_and_scripts/validation_meal_event/ParamsDiab.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 6.75
 ALL LIVER glycogenToGlucoseInLiver_ 1.25
 ALL LIVER gngLiver_ 0.38
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.38
+ALL KIDNEY gngKidneys_ 0.38
 ALL HUMAN_BODY gngImpact_ 6.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2

--- a/conf_files_and_scripts/validation_meal_event/ParamsNormal.txt
+++ b/conf_files_and_scripts/validation_meal_event/ParamsNormal.txt
@@ -10,7 +10,7 @@ ALL LIVER glucoseToGlycogenInLiver_ 4.5
 ALL LIVER glycogenToGlucoseInLiver_ 0.9
 ALL LIVER gngLiver_ 0.16
 ALL LIVER maxLipogenesis_ 400.0
-ALL KIDNEYS gngKidneys_ 0.16
+ALL KIDNEY gngKidneys_ 0.16
 ALL HUMAN_BODY gngImpact_ 6.0
 ALL HUMAN_BODY liverGlycogenBreakdownImpact_ 6.0
 ALL HUMAN_BODY intensityPeakGlucoseProd_ 0.2


### PR DESCRIPTION
In the validation_meal_event and validation_exercise_event folders, ParamsNormal.txt and ParamsDiag.txt misspell the organ "KIDNEY" as "KIDNEYS"  when setting the *gngKidneys_* parameter. This leads it to be ignored by Kidneys::setParams. When validating normal metabolic parameters this bug is hidden since the default value of gngKidneys_ equals the normal value. This bug does affect validation of diabetic parameters. I am unable to comment on how this affects validation as published in the CarbMetSim paper. However, this bug leads to dramatically different values in much of the output. I've included outDiab.diff in the root folder which shows the differences when running the meal event validation with diabetic parameters and a seed "alpha".